### PR TITLE
Fix grid visibility and toggle/snap-to-grid behavior

### DIFF
--- a/src/components/svg/Sheet.tsx
+++ b/src/components/svg/Sheet.tsx
@@ -1626,11 +1626,18 @@ export class TSheet extends React.PureComponent<TSheetProps, TSheetState> {
                 <defs>
                   <pattern
                     id="grid-pattern"
+                    x={-this.props.details.grid / 2}
+                    y={-this.props.details.grid / 2}
                     width={this.props.details.grid}
                     height={this.props.details.grid}
                     patternUnits="userSpaceOnUse"
                   >
-                    <circle cx="0" cy="0" r="0.5" fill="#a0a0a0" />
+                    <circle
+                      cx={this.props.details.grid / 2}
+                      cy={this.props.details.grid / 2}
+                      r="0.75"
+                      fill="#a0a0a0"
+                    />
                   </pattern>
                 </defs>
       
@@ -1804,11 +1811,18 @@ export class TSheet extends React.PureComponent<TSheetProps, TSheetState> {
             <defs>
               <pattern
                 id="grid-pattern"
+                x={-this.props.details.grid / 2}
+                y={-this.props.details.grid / 2}
                 width={this.props.details.grid}
                 height={this.props.details.grid}
                 patternUnits="userSpaceOnUse"
               >
-                <circle cx="0" cy="0" r="0.5" fill="#a0a0a0" />
+                <circle
+                  cx={this.props.details.grid / 2}
+                  cy={this.props.details.grid / 2}
+                  r="0.75"
+                  fill="#a0a0a0"
+                />
               </pattern>
             </defs>
 

--- a/src/manipulators/snap.ts
+++ b/src/manipulators/snap.ts
@@ -18,7 +18,15 @@ export class Snap {
 
   // Perform the snapping
   snap(p: Coordinate): Coordinate {
-    const grid = this._grid_snap ? this._grid : 1;
+    if (!this._grid_snap) {
+      let r: Coordinate = [p[0], p[1]];
+      if (p.length > 2) {
+        // For polygon control points
+        r.push(1);
+      }
+      return r;
+    }
+    const grid = this._grid;
     let r: Coordinate = [
       Math.round(p[0] / grid) * grid,
       Math.round(p[1] / grid) * grid,
@@ -33,7 +41,15 @@ export class Snap {
 
   // Perform the snapping in a positive direction only
   snap_positive(p: Coordinate): Coordinate {
-    const grid = this._grid_snap ? this._grid : 1;
+    if (!this._grid_snap) {
+      let r: Coordinate = [p[0], p[1]];
+      if (p.length > 2) {
+        // For polygon control points
+        r.push(1);
+      }
+      return r;
+    }
+    const grid = this._grid;
     let r = this.snap(p);
 
     // Make sure snapping is positive
@@ -53,7 +69,15 @@ export class Snap {
 
   // Perform the snapping in a negative direction only
   snap_negative(p: Coordinate): Coordinate {
-    const grid = this._grid_snap ? this._grid : 1;
+    if (!this._grid_snap) {
+      let r: Coordinate = [p[0], p[1]];
+      if (p.length > 2) {
+        // For polygon control points
+        r.push(1);
+      }
+      return r;
+    }
+    const grid = this._grid;
     let r = this.snap(p);
 
     // Make sure snapping is negative


### PR DESCRIPTION
This PR resolves #23.

### Summary of Changes

#### 1. Grid Visibility (`src/components/svg/Sheet.tsx`)
* **Root Cause:** The grid was rendered as an SVG `<pattern>` tiling dots of radius `0.5` centered at coordinate `(0, 0)` of each tile. By default, SVG pattern elements clip drawings to the pattern bounds `[0, width] x [0, height]`. Since the circle's center is at `(0, 0)`, three-quarters of the circle was clipped in negative pattern space, leaving only a tiny `0.25px` quadrant in the top-left of each tile. On standard resolution screens (and at zoom levels <= 100%), this `0.25px` dot was completely invisible.
* **Fix:** Centered the circle within the pattern tile at `(grid / 2, grid / 2)` to prevent clipping, and offset the pattern itself by `(-grid / 2, -grid / 2)` using the pattern's `x` and `y` attributes. This ensures the dots align perfectly with the absolute coordinate grid points while rendering the full, unclipped circle. We also slightly increased the radius to `0.75` (diameter 1.5px) for optimal visibility under different display zoom scales.

#### 2. Snap-to-Grid Behavior (`src/manipulators/snap.ts`)
* **Root Cause:** When "snap to grid" is toggled off (`_grid_snap` is `false`), the grid size fell back to `1`. This still rounded coordinates to the nearest integer. In TinyCAD, the internal coordinate system is multiplied by 5, meaning rounding to integer coordinates is still a coarse snap-to-grid operation that restricts smooth cursor movement and element placement.
* **Fix:** Bypassed the rounding/snapping logic completely when `_grid_snap` is `false`, returning the original cursor coordinate `p` unmodified to allow fully smooth movement and positioning.

---
_This pull request was created by an AI agent (OpenHands) on behalf of the user._